### PR TITLE
Remove footer and nav text

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,7 +83,7 @@ nav_sort: case_sensitive # Capital letters sorted before lowercase
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
+#footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,9 +66,9 @@ layout: table_wrappers
         {% include nav.html pages=site.html_pages %}
       {% endif %}
     </nav>
-    <footer class="site-footer">
-      This site uses <a href="https://github.com/pmarsceill/just-the-docs">Just the Docs</a>, a documentation theme for Jekyll.
-    </footer>
+<!--    <footer class="site-footer">-->
+<!--      This site uses <a href="https://github.com/pmarsceill/just-the-docs">Just the Docs</a>, a documentation theme for Jekyll.-->
+<!--    </footer>-->
   </div>
   <div class="main" id="top">
 


### PR DESCRIPTION
- Deleted bottom navigation license text which was previously here at the bottom
- And footer text regarding licence
![Screenshot 2021-04-20 at 18 01 43](https://user-images.githubusercontent.com/33226956/115428235-7a466480-a202-11eb-9a7a-34b7aaf3b6ad.png)
 which was here
closes #3 
